### PR TITLE
Add syntax for "double successes"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,6 @@ readme = "README.md"
 pest = "2.1.3"
 pest_derive = "2.1.0"
 rand = "0.7.3"
+
+[dev-dependencies]
+rand_core = "0.5.1"

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ r#  : Reroll if <= value
 ir# : Indefinite reroll if <= value
 
 Target:
-t# : minimum value to count as success
+t#  : minimum value to count as success
+tt# : minimum value to count as two successes
 
 Failure:
 f# : value under which it's counted as failure

--- a/src/caith.pest
+++ b/src/caith.pest
@@ -8,12 +8,12 @@ sub = { "-" }
 mul = { "*" }
 div = { "/" }
 
-dice = { nb_dice? ~ (roll ~ dice_side) ~ option* ~ target_failure{, 2} }
+dice = { nb_dice? ~ (roll ~ dice_side) ~ option* ~ target_failure{, 3} }
 dice_side = _{ number | fudge }
 fudge = { "F" | "f" }
 roll = { "d" | "D" }
 option = _{ explode | i_explode | reroll | i_reroll | keep_hi | keep_lo | drop_hi | drop_lo }
-target_failure = _{ target | failure }
+target_failure = _{ target | double_target | failure }
 explode = { "e" ~ number }
 i_explode = { ("ie" | "!") ~ number? }
 reroll = { "r" ~ number }
@@ -23,6 +23,7 @@ keep_lo = { "k" ~ number }
 drop_hi = { "D" ~ number }
 drop_lo = { "d" ~ number }
 target =  { "t" ~ number }
+double_target = { "tt" ~ number }
 failure =  { "f" ~ number }
 
 repeated_expr = { "(" ~ expr ~ ")" ~ "^" ~ (add | sort)? ~ number }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -392,4 +392,18 @@ mod tests {
             assert!(false);
         }
     }
+
+    #[test]
+    fn target_number_test() {
+        let r = Roller::new("10d10 t7").unwrap();
+        let res = r.roll_with_source(&mut IteratorDiceRollSource{iterator: &mut (1..11)}).unwrap();
+        println!("{}", res);
+        let res = res.get_result();
+        if let RollResultType::Single(res) = res {
+            // We rolled one of every number, with a target number of 7 we should score a success on the 7, 8, 9, and 10. So four total.
+            assert_eq!(res.get_total(), 4);
+        } else {
+            assert!(false);
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -406,4 +406,48 @@ mod tests {
             assert!(false);
         }
     }
+
+    #[test]
+    fn target_number_double_test() {
+        let r = Roller::new("10d10 t7 tt9").unwrap();
+        let res = r.roll_with_source(&mut IteratorDiceRollSource{iterator: &mut (1..11)}).unwrap();
+        println!("{}", res);
+        let res = res.get_result();
+        if let RollResultType::Single(res) = res {
+            // We rolled one of every number. That's a success each for the 7 and 8, and two success each for the 9 and 10. So a toal of six.
+            assert_eq!(res.get_total(), 6);
+        } else {
+            assert!(false);
+        }
+    }
+
+    // Where a user has asked for a doubles threashold that is lower than the single threashold, the single threashold is ignored.
+    #[test]
+    fn target_number_double_lower_than_target_test() {
+        let r = Roller::new("10d10 tt7 t9").unwrap();
+        let res = r.roll_with_source(&mut IteratorDiceRollSource{iterator: &mut (1..11)}).unwrap();
+        println!("{}", res);
+        let res = res.get_result();
+        if let RollResultType::Single(res) = res {
+            // We rolled one of every number. That's two successes each for the 7, 8, 9, and 10. So eight total.
+            assert_eq!(res.get_total(), 8);
+        } else {
+            assert!(false);
+        }
+    }
+
+    // Where a user has asked for a doubles without singles.
+    #[test]
+    fn target_number_double_only() {
+        let r = Roller::new("10d10 tt8").unwrap();
+        let res = r.roll_with_source(&mut IteratorDiceRollSource{iterator: &mut (1..11)}).unwrap();
+        println!("{}", res);
+        let res = res.get_result();
+        if let RollResultType::Single(res) = res {
+            // We rolled one of every number. That's two successes each for the 8, 9, and 10. So six total.
+            assert_eq!(res.get_total(), 6);
+        } else {
+            assert!(false);
+        }
+    }
 }

--- a/src/rollresult.rs
+++ b/src/rollresult.rs
@@ -313,7 +313,7 @@ impl SingleRollResult {
                     }
                 }
                 TotalModifier::None(_)
-                | TotalModifier::TargetFailure(_, _)
+                | TotalModifier::TargetFailureDouble(_, _, _)
                 | TotalModifier::Fudge => (),
             }
 
@@ -323,16 +323,18 @@ impl SingleRollResult {
                 TotalModifier::DropHi(n) => &flat[..flat.len() - n],
                 TotalModifier::DropLo(n) => &flat[n..],
                 TotalModifier::None(_)
-                | TotalModifier::TargetFailure(_, _)
+                | TotalModifier::TargetFailureDouble(_, _, _)
                 | TotalModifier::Fudge => flat.as_slice(),
             };
 
             self.total = match modifier {
-                TotalModifier::TargetFailure(t, f) => slice.iter().fold(0, |acc, x| {
+                TotalModifier::TargetFailureDouble(t, f, d) => slice.iter().fold(0, |acc, x| {
                     let x = *x as u64;
-                    if x >= t {
+                    if d > 0 && x >= d {
+                        acc + 2
+                    } else if t > 0 && x >= t {
                         acc + 1
-                    } else if x <= f {
+                    } else if f > 0 && x <= f {
                         acc - 1
                     } else {
                         acc


### PR DESCRIPTION
Add a `tt#` syntax which defines a threashold value above which a dice is counted as two successes, instead of just one. For example using the expression `6d10 t7 tt10` would roll six d10's where any 7, 8, or 9 would count for one success while a 10 would count for two. The `tt` syntax may be used alone, or in conjunction with either or both of the target and failure features. This enables the library to be used for games such as Exalted and Scion, which use a dice pool of d10's with successes at 7+ and double successes on 10's.

I've also included a change to enable deterministic testing. I've modified the roller logic to define a custom `DiceRollSource` trait instead of using `rand::Rng` directly. The `roll` and `roll_with` functions use a new struct `RngDiceRollSource` which implements `DiceRollSource` using `gen_range` as before. This inderection allows tests to provide alternative implementations of `DiceRollSource` to test spesific logic. The tests for the new feature are supported by an `IteratorDiceRollSource` implementation that allows the tests to pass a list or range to define the dice they want to test with.

If preferred, this testing change could be removed entirely from this pull request or split into a second pull request for further consideration.