### PR TITLE
set up a basic fuzz target

### DIFF
--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+
+target
+corpus
+artifacts

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,33 @@
+
+[package]
+name = "caith-fuzz"
+version = "0.0.0"
+authors = ["Automatically generated"]
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+mice = "0.10.4"
+
+[dependencies.caith]
+path = ".."
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "raw_parser"
+path = "fuzz_targets/raw_parser.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "guarded_roller"
+path = "fuzz_targets/guarded_roller.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/guarded_roller.rs
+++ b/fuzz/fuzz_targets/guarded_roller.rs
@@ -1,0 +1,20 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+use ::caith::Roller;
+// I used the dice parser from my own dice crate to guard
+// the parser from this crate from seeing invalid dice expressions.
+// The dice parser from my crate only accepts a subset of this crate's
+// dice language, but it works to demonstrate a failure inside
+// the roller itself, beyond the parsing problems.
+use ::mice::parse::parse_expression;
+
+fuzz_target!(|data: &str| {
+    if let Ok((rest, _)) = parse_expression(data.as_bytes()) {
+        if rest.is_empty() {
+            if let Ok(roller) = Roller::new(data) {
+                let _ = roller.roll();
+            }
+        }
+    }
+});

--- a/fuzz/fuzz_targets/raw_parser.rs
+++ b/fuzz/fuzz_targets/raw_parser.rs
@@ -1,0 +1,11 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+use ::caith::Roller;
+use ::mice::parse::parse_expression;
+
+fuzz_target!(|data: &str| {
+    if let Ok(roller) = Roller::new(data) {
+        let _ = roller.roll();
+    }
+});


### PR DESCRIPTION
Using [`cargo fuzz`](https://rust-fuzz.github.io/book/cargo-fuzz/setup.html) to find failures in input and dice expression handling.

There is at least one wrongful `.unwrap()` in this crate's integer parsing, and at least one issue where the roller can be made to allocate far too much memory and OOM crash.