### PR TITLE
Fix no-op reroll case

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -746,7 +746,6 @@ mod tests {
 
         assert_eq!(numeric.get_total(), 1);
         assert_eq!(as_string, "[1] = 1");
-        // Not sure how the history works, maybe this is expected?
         assert_eq!(history, "[1]");
     }
 
@@ -762,7 +761,7 @@ mod tests {
 
         assert_eq!(numeric.get_total(), 1);
         assert_eq!(as_string, "[1] = 1");
-        // Not sure how the history works, maybe this is expected?
+        // Rerolls are currently not displayed in the history
         assert_eq!(history, "[1]");
     }
 
@@ -776,14 +775,8 @@ mod tests {
         let history = numeric.to_string_history();
         let as_string = numeric.to_string(false);
 
-        // For an unknown reason this roll is producing 0 and not 1.
         assert_eq!(numeric.get_total(), 1);
-
-        // The formatted string output is just "0", which also seems wrong.
-        // Thus currently failing:
         assert_eq!(as_string, "[1] = 1");
-
-        // The "history" is an empty string. Not sure if this is expected.
-        assert_eq!(history, "");
+        assert_eq!(history, "[1]");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -733,4 +733,57 @@ mod tests {
 
         eprintln!("{}\n{}", r.as_str(), r.roll().unwrap());
     }
+
+    #[test]
+    fn caith_minimal() {
+        // This should deterministically roll a 1
+        let roller = Roller::new(&"1d1").unwrap();
+
+        let result = roller.roll().unwrap();
+        let numeric = result.as_single().unwrap();
+        let history = numeric.to_string_history();
+        let as_string = numeric.to_string(false);
+
+        assert_eq!(numeric.get_total(), 1);
+        assert_eq!(as_string, "[1] = 1");
+        // Not sure how the history works, maybe this is expected?
+        assert_eq!(history, "[1]");
+    }
+
+    #[test]
+    fn caith_reroll() {
+        // This should deterministically roll a 1, then reroll 1
+        let roller = Roller::new(&"1d1 r1").unwrap();
+
+        let result = roller.roll().unwrap();
+        let numeric = result.as_single().unwrap();
+        let history = numeric.to_string_history();
+        let as_string = numeric.to_string(false);
+
+        assert_eq!(numeric.get_total(), 1);
+        assert_eq!(as_string, "[1] = 1");
+        // Not sure how the history works, maybe this is expected?
+        assert_eq!(history, "[1]");
+    }
+
+    #[test]
+    fn caith_no_reroll() {
+        // This should deterministically roll a 1, then not reroll anything since 1 > 0
+        let roller = Roller::new(&"1d1 r0").unwrap();
+
+        let result = roller.roll().unwrap();
+        let numeric = result.as_single().unwrap();
+        let history = numeric.to_string_history();
+        let as_string = numeric.to_string(false);
+
+        // For an unknown reason this roll is producing 0 and not 1.
+        assert_eq!(numeric.get_total(), 1);
+
+        // The formatted string output is just "0", which also seems wrong.
+        // Thus currently failing:
+        assert_eq!(as_string, "[1] = 1");
+
+        // The "history" is an empty string. Not sure if this is expected.
+        assert_eq!(history, "");
+    }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -156,9 +156,9 @@ fn compute_reroll<RNG: DiceRollSource>(
         })
         .collect();
 
-    if has_rerolled {
+    // Original roll is not included in history, so add the result, regardless of if a reroll occurred.
         rolls.add_history(res.clone(), false);
-    }
+
     (TotalModifier::None(Rule::reroll), res)
 }
 


### PR DESCRIPTION
This fixes the bug reported in https://github.com/Geobert/caith/issues/5

It seems a bit odd not to track the original rolls in the history when re-rolling re-rolls in the history, but that appears to be what's happening. This results in cases which don't re-roll but could have not tracking any history which is the source of the bug.